### PR TITLE
release arm64/amd64 docker images automatically using Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Docker login
+        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist --debug
+        env:
+          # create personal access token: https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 *vendor*
 
 smtp_to_telegram
+
+# IntelliJ
+/smtp_to_telegram.iml
+/.idea/
+
+# goreleaser
+/dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,32 @@
+before:
+  hooks:
+    - go mod download
+builds:
+- env:
+  - CGO_ENABLED=0
+  binary: smtp_to_telegram
+  goarch:
+      - amd64
+      - arm64
+checksum:
+  name_template: 'checksums.txt'
+dockers:
+  - image_templates:
+      - "kostyaesmukov/smtp_to_telegram:{{ .Version }}-amd64"
+      - "kostyaesmukov/smtp_to_telegram:latest-amd64"
+    binaries:
+      - smtp_to_telegram
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--build-arg"
+      - "ARCH=amd64"
+  - image_templates:
+      - "kostyaesmukov/smtp_to_telegram:{{ .Version }}-arm64v8"
+      - "kostyaesmukov/smtp_to_telegram:latest-arm64v8"
+    binaries:
+      - smtp_to_telegram
+    goarch: arm64
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--build-arg"
+      - "ARCH=arm64v8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,16 @@
-FROM golang:1.13-alpine3.10 AS builder
+ARG ARCH
 
-RUN apk add --no-cache git ca-certificates
+FROM alpine:latest as certs
+RUN apk --update --no-cache add ca-certificates && update-ca-certificates
 
-WORKDIR /app
+FROM ${ARCH}/alpine
 
-COPY . .
-
-# The image should be built with
-# --build-arg ST_VERSION=`git describe --tags --always`
-ARG ST_VERSION
-RUN CGO_ENABLED=0 GOOS=linux go build \
-        -ldflags "-s -w \
-            -X main.Version=${ST_VERSION:-UNKNOWN_RELEASE}" \
-        -a -o smtp_to_telegram
-
-
-
-
-
-FROM alpine:3.10
-
-RUN apk add --no-cache ca-certificates
-
-COPY --from=builder /app/smtp_to_telegram /smtp_to_telegram
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY smtp_to_telegram /usr/bin/smtp_to_telegram
 
 USER daemon
 
 ENV ST_SMTP_LISTEN "0.0.0.0:2525"
 EXPOSE 2525
 
-ENTRYPOINT ["/smtp_to_telegram"]
+ENTRYPOINT ["/usr/bin/smtp_to_telegram"]

--- a/smtp_to_telegram.go
+++ b/smtp_to_telegram.go
@@ -20,7 +20,9 @@ import (
 )
 
 var (
-	Version string = "UNKNOWN_RELEASE"
+	version string = "UNKNOWN_RELEASE"
+	commit  string
+	date    string
 )
 
 type SmtpConfig struct {
@@ -48,7 +50,7 @@ func main() {
 	app.Name = "smtp_to_telegram"
 	app.Usage = "A small program which listens for SMTP and sends " +
 		"all incoming Email messages to Telegram."
-	app.Version = Version
+	app.Version = fmt.Sprintf("%s (commit: %s build-ts: %s)", version, commit, date)
 	app.Action = func(c *cli.Context) error {
 		// Required flags are not supported, see https://github.com/urfave/cli/issues/85
 		if !c.IsSet("telegram-chat-ids") {


### PR DESCRIPTION
Hey,

I just added this in a fork to get an arm64 docker image.
With this PR amd64/arm64 docker images will be published automatically when you push a version tag.
Additionally, pre-build artifacts are available on the release page (see: https://github.com/random-dwi/smtp-gotify/releases/tag/v1.0.1)

If you want to merge this you have to add the following secrets for your repo:
-  `DOCKER_USERNAME`: kostyaesmukov
- `DOCKER_PASSWORD`: password for docker hub
- `GH_PAT`: github personal access token (https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)

Afterwards all you need to do a release is:
```
git tag v1.0.0
git push origin v1.0.0
```

Cheers, Dirk
