### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: goreleaser
+
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - '*.*.*'
+      - '*.*.*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 smtp_to_telegram
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,8 @@ builds:
       - '7'
     ldflags:
       - -s -w -X main.Version={{.Version}}
+    tags:
+      - urfave_cli_no_docs
 
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,57 @@
+project_name: smtp_to_telegram
+
+release:
+  prerelease: auto
+
+builds:
+  - id: smtp_to_telegram
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - '7'
+    ldflags:
+      - -s -w -X main.Version={{.Version}}
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+dockers:
+  - &xdocker
+    image_templates:
+      - kostyaesmukov/{{ .ProjectName }}:{{ .Version }}-amd64
+    dockerfile: Dockerfile.release
+    use: buildx
+    goos: linux
+    goarch: amd64
+    build_flag_templates:
+      - --platform=linux/amd64
+
+  - <<: *xdocker
+    image_templates:
+      - kostyaesmukov/{{ .ProjectName }}:{{ .Version }}-arm64
+    goarch: arm64
+    build_flag_templates:
+      - --platform=linux/arm64/v8
+
+  - <<: *xdocker
+    image_templates:
+      - kostyaesmukov/{{ .ProjectName }}:{{ .Version }}-armv7
+    goarch: arm
+    goarm: 7
+    build_flag_templates:
+      - --platform=linux/arm/v7
+
+docker_manifests:
+  - name_template: kostyaesmukov/{{ .ProjectName }}:latest
+    image_templates:
+    - kostyaesmukov/{{ .ProjectName }}:{{ .Version }}-amd64
+    - kostyaesmukov/{{ .ProjectName }}:{{ .Version }}-arm64
+    - kostyaesmukov/{{ .ProjectName }}:{{ .Version }}-armv7

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ RUN apk add --no-cache git ca-certificates mailcap
 
 WORKDIR /app
 
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
 
 # The image should be built with

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ARG GOPROXY=direct
 RUN CGO_ENABLED=0 GOOS=linux go build \
         -ldflags "-s -w \
             -X main.Version=${ST_VERSION:-UNKNOWN_RELEASE}" \
+        -tags urfave_cli_no_docs \
         -a -o smtp_to_telegram
 
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,12 @@
+FROM alpine:3.16
+
+RUN apk add --no-cache ca-certificates mailcap
+
+COPY smtp_to_telegram /smtp_to_telegram
+
+USER daemon
+
+ENV ST_SMTP_LISTEN="0.0.0.0:2525"
+EXPOSE 2525
+
+ENTRYPOINT ["/smtp_to_telegram"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+GOLANG_CROSS_VERSION  ?= v1.18.1
+
+test-release:
+	@docker run \
+		--rm \
+		--privileged \
+		-v ${PWD}:/smtp_to_telegram \
+		-w /smtp_to_telegram \
+		-e GITHUB_TOKEN \
+		-e DOCKER_USERNAME \
+		-e DOCKER_PASSWORD \
+		-e DOCKER_REGISTRY \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		--rm-dist --skip-validate --timeout=1h --snapshot


### PR DESCRIPTION
* Releases via Github Actions
* Include arm v7 and arm64 builds (for raspberry pis)

To make a release, we just create a new (empty) release (via Github UI) or push a new tag.

Github action will upload binaries as release assets, push docker image and update release description with changelog

Also added build tag `urfave_cli_no_docs` as documented [here](https://cli.urfave.org/#urfave_cli_no_docs), removing unused code from compiled asset