### PR TITLE
add `--telegram-bot-token-file` to read token from file

### DIFF
--- a/smtp_to_telegram.go
+++ b/smtp_to_telegram.go
@@ -5,13 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	units "github.com/docker/go-units"
-	"github.com/flashmob/go-guerrilla"
-	"github.com/flashmob/go-guerrilla/backends"
-	"github.com/flashmob/go-guerrilla/log"
-	"github.com/flashmob/go-guerrilla/mail"
-	"github.com/jhillyerd/enmime"
-	"github.com/urfave/cli/v2"
 	"io/ioutil"
 	"mime"
 	"mime/multipart"
@@ -23,6 +16,14 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	units "github.com/docker/go-units"
+	"github.com/flashmob/go-guerrilla"
+	"github.com/flashmob/go-guerrilla/backends"
+	"github.com/flashmob/go-guerrilla/log"
+	"github.com/flashmob/go-guerrilla/mail"
+	"github.com/jhillyerd/enmime"
+	"github.com/urfave/cli/v2"
 )
 
 var (
@@ -94,6 +95,20 @@ func main() {
 		"all incoming Email messages to Telegram."
 	app.Version = Version
 	app.Action = func(c *cli.Context) error {
+		var telegramBotToken string
+		if c.String("telegram-bot-token") == "" {
+			if c.String("telegram-bot-token-file") == "" {
+				return fmt.Errorf("either --telegram-bot-token or --telegram-bot-token-file is required")
+			} else {
+				bytes, err := ioutil.ReadFile(c.String("telegram-bot-token-file"))
+				if err != nil {
+					return err
+				}
+				telegramBotToken = strings.TrimSpace(string(bytes))
+			}
+		} else {
+			telegramBotToken = c.String("telegram-bot-token")
+		}
 		smtpMaxEnvelopeSize, err := units.FromHumanSize(c.String("smtp-max-envelope-size"))
 		if err != nil {
 			fmt.Printf("%s\n", err)
@@ -116,7 +131,7 @@ func main() {
 		}
 		telegramConfig := &TelegramConfig{
 			telegramChatIds:                  c.String("telegram-chat-ids"),
-			telegramBotToken:                 c.String("telegram-bot-token"),
+			telegramBotToken:                 telegramBotToken,
 			telegramApiPrefix:                c.String("telegram-api-prefix"),
 			telegramApiTimeoutSeconds:        c.Float64("telegram-api-timeout-seconds"),
 			messageTemplate:                  c.String("message-template"),
@@ -158,10 +173,15 @@ func main() {
 			Required: true,
 		},
 		&cli.StringFlag{
-			Name:     "telegram-bot-token",
-			Usage:    "Telegram: bot token",
-			EnvVars:  []string{"ST_TELEGRAM_BOT_TOKEN"},
-			Required: true,
+			Name:    "telegram-bot-token",
+			Usage:   "Telegram: bot token",
+			EnvVars: []string{"ST_TELEGRAM_BOT_TOKEN"},
+		},
+		&cli.StringFlag{
+			Name:      "telegram-bot-token-file",
+			Usage:     "Telegram: file containing bot token",
+			TakesFile: true,
+			EnvVars:   []string{"ST_TELEGRAM_BOT_TOKEN_FILE"},
 		},
 		&cli.StringFlag{
 			Name:    "telegram-api-prefix",


### PR DESCRIPTION
This is useful not only when using docker secrets but also to keep token out of process tree

As a note, this was the first time I saw this `cli` package (more used to [cobra](https://cobra.dev/)) and I couldn't find any clean way to add support for `_FILE` in the same flag.  
Also, doing that would prevent normal flag usage (instead of env) to use a file for the token (and keep it away from process tree).

So I created a separate flag.

Again, I couldn't find any way to do post-flag parsing validations (to add the `either required` check), so I ended up adding it in the main action. The usage error in `cli` is private so I could not re-use it (which would look better/more standard in output).